### PR TITLE
Refactor domain use cases to use specialized repositories

### DIFF
--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/episodedetails/GetCastForEpisodeUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/episodedetails/GetCastForEpisodeUseCase.kt
@@ -1,17 +1,17 @@
 package com.elhady.movies.core.domain.usecase.details.episodedetails
 
 import com.elhady.movies.core.domain.model.PeopleEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.TvShowRepository
 import javax.inject.Inject
 
 class GetCastForEpisodeUseCase @Inject constructor(
-    private val movieRepository: MovieRepository
+    private val tvShowRepository: TvShowRepository
 ) {
     suspend operator fun invoke(
         id: Int,
         seasonNumber: Int,
         episodeNumber: Int
     ): List<PeopleEntity> {
-        return movieRepository.getCastForEpisode(id, seasonNumber, episodeNumber)
+        return tvShowRepository.getCastForEpisode(id, seasonNumber, episodeNumber)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/episodedetails/GetEpisodeVideoUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/episodedetails/GetEpisodeVideoUseCase.kt
@@ -1,17 +1,17 @@
 package com.elhady.movies.core.domain.usecase.details.episodedetails
 
 import com.elhady.movies.core.domain.model.YoutubeVideoDetailsEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.TvShowRepository
 import javax.inject.Inject
 
 class GetEpisodeVideoUseCase  @Inject constructor(
-    private val movieRepository: MovieRepository
+    private val tvShowRepository: TvShowRepository
 )  {
     suspend operator fun invoke(
         id: Int,
         seasonNumber: Int,
         episodeNumber: Int,
     ): YoutubeVideoDetailsEntity {
-        return movieRepository.getVideoEpisodeDetails(id, seasonNumber, episodeNumber)
+        return tvShowRepository.getVideoEpisodeDetails(id, seasonNumber, episodeNumber)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/episodedetails/SetEpisodeRatingUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/episodedetails/SetEpisodeRatingUseCase.kt
@@ -1,11 +1,11 @@
 package com.elhady.movies.core.domain.usecase.details.episodedetails
 
 import com.elhady.movies.core.domain.model.RatingEpisodeDetailsStatusEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.TvShowRepository
 import javax.inject.Inject
 
 class SetEpisodeRatingUseCase @Inject constructor(
-    private val movieRepository: MovieRepository
+    private val tvShowRepository: TvShowRepository
 ) {
     suspend operator fun invoke(
         seriesId: Int,
@@ -13,6 +13,6 @@ class SetEpisodeRatingUseCase @Inject constructor(
         episodeNumber: Int,
         value: Float
     ): RatingEpisodeDetailsStatusEntity {
-        return movieRepository.setRatingForEpisode(seriesId, seasonNumber, episodeNumber, value)
+        return tvShowRepository.setRatingForEpisode(seriesId, seasonNumber, episodeNumber, value)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/moviedetails/AddToUserListUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/moviedetails/AddToUserListUseCase.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.details.moviedetails
 
 import com.elhady.movies.core.domain.model.StatusEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.AccountRepository
 import javax.inject.Inject
 
 class AddToUserListUseCase @Inject constructor(
-    private val movieRepository: MovieRepository
+    private val accountRepository: AccountRepository
 ) {
     suspend operator fun invoke(listId: Int, mediaId: Int): StatusEntity {
-        return movieRepository.postUserLists(listId, mediaId)
+        return accountRepository.postUserLists(listId, mediaId)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/moviedetails/CreateUserListUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/moviedetails/CreateUserListUseCase.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.details.moviedetails
 
 import com.elhady.movies.core.domain.model.StatusEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.AccountRepository
 import javax.inject.Inject
 
 class CreateUserListUseCase @Inject constructor(
-    private val movieRepository: MovieRepository
+    private val accountRepository: AccountRepository
 ) {
     suspend operator fun invoke(listName: String): StatusEntity {
-        return movieRepository.createUserList(listName)
+        return accountRepository.createUserList(listName)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/moviedetails/GetRatingMovieUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/moviedetails/GetRatingMovieUseCase.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.details.moviedetails
 
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.AccountRepository
 import javax.inject.Inject
 
 class GetRatingMovieUseCase @Inject constructor(
-    private val movieRepository: MovieRepository
+    private val accountRepository: AccountRepository
 ) {
     suspend operator fun invoke(movieId: Int): Float {
-        val rating = movieRepository.getMovieRate().find {
+        val rating = accountRepository.getMovieRate().find {
             it.id == movieId
         }?.myRate ?: 0.0
         return rating.toFloat()

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/moviedetails/GetUserListsUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/moviedetails/GetUserListsUseCase.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.details.moviedetails
 
 import com.elhady.movies.core.domain.model.UserListEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.AccountRepository
 import javax.inject.Inject
 
 class GetUserListsUseCase @Inject constructor(
-    private val movieRepository: MovieRepository,
+    private val accountRepository: AccountRepository,
 ) {
     suspend operator fun invoke(): List<UserListEntity> {
-        return movieRepository.getUserLists()
+        return accountRepository.getUserLists()
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/moviedetails/SetRatingUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/moviedetails/SetRatingUseCase.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.details.moviedetails
 
 import com.elhady.movies.core.domain.model.StatusEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.AccountRepository
 import javax.inject.Inject
 
 class SetRatingUseCase @Inject constructor(
-    private val movieRepository: MovieRepository
+    private val accountRepository: AccountRepository
 ) {
     suspend operator fun invoke(movieId:Int , rate:Float): StatusEntity {
-        return movieRepository.setMovieRate(movieId , rate)
+        return accountRepository.setMovieRate(movieId , rate)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/people/GetMoviesByPersonUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/people/GetMoviesByPersonUseCase.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.details.people
 
 import com.elhady.movies.core.domain.model.MovieEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.PeopleRepository
 import javax.inject.Inject
 
 class GetMoviesByPersonUseCase @Inject constructor(
-    private val movieRepository: MovieRepository,
+    private val peopleRepository: PeopleRepository,
 ) {
     suspend operator fun invoke(personId:Int): List<MovieEntity>{
-        return movieRepository.getMoviesByPerson(personId)
+        return peopleRepository.getMoviesByPerson(personId)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/tvdetails/AddToUserListUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/tvdetails/AddToUserListUseCase.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.details.tvdetails
 
 import com.elhady.movies.core.domain.model.StatusEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.AccountRepository
 import javax.inject.Inject
 
 class AddToUserListUseCase @Inject constructor(
-    private val movieRepository: MovieRepository
+    private val accountRepository: AccountRepository
 ) {
     suspend operator fun invoke(listId: Int, mediaId: Int): StatusEntity {
-        return movieRepository.postUserLists(listId, mediaId)
+        return accountRepository.postUserLists(listId, mediaId)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/tvdetails/CreateUserListUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/tvdetails/CreateUserListUseCase.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.details.tvdetails
 
 import com.elhady.movies.core.domain.model.StatusEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.AccountRepository
 import javax.inject.Inject
 
 class CreateUserListUseCase @Inject constructor(
-    private val movieRepository: MovieRepository
+    private val accountRepository: AccountRepository
 ) {
     suspend operator fun invoke(listName: String): StatusEntity {
-        return movieRepository.createUserList(listName)
+        return accountRepository.createUserList(listName)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/tvdetails/GetRatingTvUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/tvdetails/GetRatingTvUseCase.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.details.tvdetails
 
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.TvShowRepository
 import javax.inject.Inject
 
 class GetRatingTvUseCase @Inject constructor(
-    private val movieRepository: MovieRepository
+    private val tvShowRepository: TvShowRepository
 ) {
     suspend operator fun invoke(tvShowId: Int): Float {
-        val rating = movieRepository.getRateTvShow().find {
+        val rating = tvShowRepository.getRateTvShow().find {
             it.id == tvShowId
         }?.rate ?: 0.0
         return rating.toFloat()

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/tvdetails/GetTvShowRecommendationsUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/tvdetails/GetTvShowRecommendationsUseCase.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.details.tvdetails
 
 import com.elhady.movies.core.domain.model.TvShowEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.TvShowRepository
 import javax.inject.Inject
 
 class GetTvShowRecommendationsUseCase @Inject constructor(
-    private val movieRepository: MovieRepository,
+    private val tvShowRepository: TvShowRepository,
 ) {
     suspend operator fun invoke(tvShowId:Int):List<TvShowEntity>{
-        return movieRepository.getTvShowRecommendations(tvShowId)
+        return tvShowRepository.getTvShowRecommendations(tvShowId)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/tvdetails/GetUserListsUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/tvdetails/GetUserListsUseCase.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.details.tvdetails
 
 import com.elhady.movies.core.domain.model.UserListEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.AccountRepository
 import javax.inject.Inject
 
 class GetUserListsUseCase @Inject constructor(
-    private val movieRepository: MovieRepository,
+    private val accountRepository: AccountRepository,
 ) {
     suspend operator fun invoke(): List<UserListEntity> {
-        return movieRepository.getUserLists()
+        return accountRepository.getUserLists()
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/tvdetails/RateTvShowUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/details/tvdetails/RateTvShowUseCase.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.details.tvdetails
 
 import com.elhady.movies.core.domain.model.StatusEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.TvShowRepository
 import javax.inject.Inject
 
 class RateTvShowUseCase @Inject constructor(
-    private val movieRepository: MovieRepository
+    private val tvShowRepository: TvShowRepository
 ) {
     suspend operator fun invoke(rate: Double, tvShowId: Int): StatusEntity {
-        return movieRepository.rateTvShow(rate, tvShowId)
+        return tvShowRepository.rateTvShow(rate, tvShowId)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/home/GetAiringTodayTvUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/home/GetAiringTodayTvUseCase.kt
@@ -1,18 +1,18 @@
 package com.elhady.movies.core.domain.usecase.home
 
 import com.elhady.movies.core.domain.model.TVShowsEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.TvShowRepository
 import com.elhady.movies.core.domain.usecase.common.RefreshIfNeededUseCase
 import javax.inject.Inject
 
 class GetAiringTodayTvUseCase @Inject constructor(
-    private val movieRepository: MovieRepository,
+    private val tvShowRepository: TvShowRepository,
     private val refreshIfNeededUseCase: RefreshIfNeededUseCase
 ) {
     suspend operator fun invoke(limit: Int = 6): List<TVShowsEntity> {
         refreshIfNeededUseCase()
-        return movieRepository.getAiringTodayTvShowsFromDatabase()
-            .also { if (it.isEmpty()) movieRepository.refreshAiringTodayTvShows() }
+        return tvShowRepository.getAiringTodayTvShowsFromDatabase()
+            .also { if (it.isEmpty()) tvShowRepository.refreshAiringTodayTvShows() }
             .take(limit)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/home/GetPopularPeopleUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/home/GetPopularPeopleUseCase.kt
@@ -1,18 +1,18 @@
 package com.elhady.movies.core.domain.usecase.home
 
 import com.elhady.movies.core.domain.model.PeopleEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.PeopleRepository
 import com.elhady.movies.core.domain.usecase.common.RefreshIfNeededUseCase
 import javax.inject.Inject
 
 class GetPopularPeopleUseCase @Inject constructor(
-    private val movieRepository: MovieRepository,
+    private val peopleRepository: PeopleRepository,
     private val refreshIfNeededUseCase: RefreshIfNeededUseCase
 ) {
     suspend operator fun invoke(limit: Int = 10): List<PeopleEntity> {
         refreshIfNeededUseCase()
-        return movieRepository.getPopularPeopleFromDatabase()
-            .also { if (it.isEmpty()) movieRepository.refreshPopularPeople() }
+        return peopleRepository.getPopularPeopleFromDatabase()
+            .also { if (it.isEmpty()) peopleRepository.refreshPopularPeople() }
             .take(limit)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/home/GetTvShowUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/home/GetTvShowUseCase.kt
@@ -1,18 +1,18 @@
 package com.elhady.movies.core.domain.usecase.home
 
 import com.elhady.movies.core.domain.model.TVShowsEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.TvShowRepository
 import com.elhady.movies.core.domain.usecase.common.RefreshIfNeededUseCase
 import javax.inject.Inject
 
 class GetTvShowUseCase @Inject constructor(
-    private val movieRepository: MovieRepository,
+    private val tvShowRepository: TvShowRepository,
     private val refreshIfNeededUseCase: RefreshIfNeededUseCase
 ) {
     suspend operator fun invoke(limit: Int = 10): List<TVShowsEntity> {
         refreshIfNeededUseCase()
-        return movieRepository.getTvShowsFromDatabase()
-            .also { if (it.isEmpty()) movieRepository.refreshTvShows() }
+        return tvShowRepository.getTvShowsFromDatabase()
+            .also { if (it.isEmpty()) tvShowRepository.refreshTvShows() }
             .take(limit)
     }
 

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/search/ClearAllSearchHistoryUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/search/ClearAllSearchHistoryUseCase.kt
@@ -1,12 +1,12 @@
 package com.elhady.movies.core.domain.usecase.search
 
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.SearchRepository
 import javax.inject.Inject
 
 class ClearAllSearchHistoryUseCase @Inject constructor(
-    private val movieRepository: MovieRepository
+    private val searchRepository: SearchRepository
 ) {
     suspend operator fun invoke(){
-        return movieRepository.clearAllSearchHistory()
+        return searchRepository.clearAllSearchHistory()
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/search/DeleteSearchHistoryUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/search/DeleteSearchHistoryUseCase.kt
@@ -1,12 +1,12 @@
 package com.elhady.movies.core.domain.usecase.search
 
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.SearchRepository
 import javax.inject.Inject
 
 class DeleteSearchHistoryUseCase @Inject constructor(
-    private val movieRepository: MovieRepository
+    private val searchRepository: SearchRepository
 ) {
     suspend operator fun invoke(keyword: String){
-        return movieRepository.deleteSearchHistory(keyword = keyword)
+        return searchRepository.deleteSearchHistory(keyword = keyword)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/search/SearchHistoryUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/search/SearchHistoryUseCase.kt
@@ -1,12 +1,12 @@
 package com.elhady.movies.core.domain.usecase.search
 
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.SearchRepository
 import javax.inject.Inject
 
 class SearchHistoryUseCase @Inject constructor(
-    private val movieRepository: MovieRepository,
+    private val searchRepository: SearchRepository,
 ) {
     suspend operator fun invoke(keyword: String): List<String> {
-        return movieRepository.getSearchHistory(keyword = keyword).sorted()
+        return searchRepository.getSearchHistory(keyword = keyword).sorted()
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/watchlist/AddToFavouriteUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/watchlist/AddToFavouriteUseCase.kt
@@ -1,17 +1,17 @@
 package com.elhady.movies.core.domain.usecase.watchlist
 
 import com.elhady.movies.core.domain.model.StatusEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.AccountRepository
 import javax.inject.Inject
 
 class AddToFavouriteUseCase @Inject constructor(
-    private val movieRepository: MovieRepository
+    private val accountRepository: AccountRepository
 ) {
     suspend operator fun invoke(
         movieId: Int,
         mediaType: String,
         isFavorite: Boolean = true
     ): StatusEntity {
-        return movieRepository.addFavouriteList(movieId, mediaType, isFavorite)
+        return accountRepository.addFavouriteList(movieId, mediaType, isFavorite)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/watchlist/AddToWatchList.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/watchlist/AddToWatchList.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.watchlist
 
 import com.elhady.movies.core.domain.model.StatusEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.AccountRepository
 import javax.inject.Inject
 
 class AddToWatchList @Inject constructor(
-    private val movieRepository: MovieRepository
+    private val accountRepository: AccountRepository
 ) {
     suspend operator fun invoke(movieId:Int, mediaType:String, isWatchlist: Boolean = true): StatusEntity {
-        return movieRepository.addWatchlist(movieId,mediaType,isWatchlist)
+        return accountRepository.addWatchlist(movieId,mediaType,isWatchlist)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/watchlist/mylist/CreateListUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/watchlist/mylist/CreateListUseCase.kt
@@ -1,12 +1,12 @@
 package com.elhady.movies.core.domain.usecase.watchlist.mylist
 
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.AccountRepository
 import javax.inject.Inject
 
 class CreateListUseCase @Inject constructor(
-    private val movieRepository: MovieRepository,
+    private val accountRepository: AccountRepository,
 ) {
     suspend operator fun invoke(nameList:String): Boolean {
-        return movieRepository.addList(name = nameList)
+        return accountRepository.addList(name = nameList)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/watchlist/mylist/DeleteListUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/watchlist/mylist/DeleteListUseCase.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.watchlist.mylist
 
 import com.elhady.movies.core.domain.model.StatusEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.AccountRepository
 import javax.inject.Inject
 
 class DeleteListUseCase @Inject constructor(
-    private val movieRepository: MovieRepository,
+    private val accountRepository: AccountRepository,
 ) {
     suspend operator fun invoke(listId: Int): StatusEntity {
-        return movieRepository.deleteList(listId =listId)
+        return accountRepository.deleteList(listId =listId)
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/watchlist/mylist/GetListsCreatedUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/watchlist/mylist/GetListsCreatedUseCase.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.watchlist.mylist
 
 import com.elhady.movies.core.domain.model.mylist.ListCreatedEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.AccountRepository
 import javax.inject.Inject
 
 class GetListsCreatedUseCase @Inject constructor(
-    private val movieRepository: MovieRepository,
+    private val accountRepository: AccountRepository,
 ) {
     suspend operator fun invoke(): List<ListCreatedEntity> {
-        return movieRepository.getListCreated()
+        return accountRepository.getListCreated()
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/watchlist/mylist/GetMyFavoriteListUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/watchlist/mylist/GetMyFavoriteListUseCase.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.watchlist.mylist
 
 import com.elhady.movies.core.domain.model.MovieEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.AccountRepository
 import javax.inject.Inject
 
 class GetMyFavoriteListUseCase @Inject constructor(
-    private val movieRepository: MovieRepository,
+    private val accountRepository: AccountRepository,
 ) {
     suspend operator fun invoke(): List<MovieEntity> {
-        return  movieRepository.getFavoriteMovies() + movieRepository.getFavoriteTv()
+        return  accountRepository.getFavoriteMovies() + accountRepository.getFavoriteTv()
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/watchlist/mylist/GetMyWatchlistListUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/watchlist/mylist/GetMyWatchlistListUseCase.kt
@@ -1,13 +1,13 @@
 package com.elhady.movies.core.domain.usecase.watchlist.mylist
 
 import com.elhady.movies.core.domain.model.MovieEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.AccountRepository
 import javax.inject.Inject
 
 class GetMyWatchlistListUseCase @Inject constructor(
-    private val movieRepository: MovieRepository,
+    private val accountRepository: AccountRepository,
 ) {
     suspend operator fun invoke(): List<MovieEntity> {
-        return  movieRepository.getWatchlistMovies() + movieRepository.getWatchlistTv()
+        return  accountRepository.getWatchlistMovies() + accountRepository.getWatchlistTv()
     }
 }

--- a/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/watchlist/myrated/GetMyRatedMoviesUseCase.kt
+++ b/core/domain/src/main/java/com/elhady/movies/core/domain/usecase/watchlist/myrated/GetMyRatedMoviesUseCase.kt
@@ -2,15 +2,15 @@ package com.elhady.movies.core.domain.usecase.watchlist.myrated
 
 import androidx.paging.PagingData
 import com.elhady.movies.core.domain.model.myrated.MyRatedMovieEntity
-import com.elhady.movies.core.domain.repository.MovieRepository
+import com.elhady.movies.core.domain.repository.AccountRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 
 class GetMyRatedMoviesUseCase @Inject constructor(
-    private val movieRepository: MovieRepository
+    private val accountRepository: AccountRepository
 ) {
     suspend operator fun invoke(): Flow<PagingData<MyRatedMovieEntity>> {
-        return movieRepository.getRatedMovies().flow
+        return accountRepository.getRatedMovies().flow
     }
 }


### PR DESCRIPTION
This change replaces the monolithic `MovieRepository` dependency with more specific repositories—`AccountRepository`, `TvShowRepository`, `SearchRepository`, and `PeopleRepository`—across various use cases to better align with the Single Responsibility Principle.