### PR TITLE
Rename `bases` package to `base` in `core:data` module

### DIFF
--- a/core/data/src/main/java/com/elhady/movies/core/data/base/BasePagingSource.kt
+++ b/core/data/src/main/java/com/elhady/movies/core/data/base/BasePagingSource.kt
@@ -1,4 +1,4 @@
-package com.elhady.movies.core.data.bases
+package com.elhady.movies.core.data.base
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState

--- a/core/data/src/main/java/com/elhady/movies/core/data/base/BaseRepository.kt
+++ b/core/data/src/main/java/com/elhady/movies/core/data/base/BaseRepository.kt
@@ -1,4 +1,4 @@
-package com.elhady.movies.core.data.bases
+package com.elhady.movies.core.data.base
 
 import com.elhady.movies.core.network.model.response.DataWrapperResponse
 import com.elhady.movies.core.common.ApiThrowable


### PR DESCRIPTION
This change renames the package from `bases` to `base` and updates the package declarations in `BasePagingSource` and `BaseRepository` for naming consistency.